### PR TITLE
8 refactor tree validator now that root is no longer required

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,9 @@
 
 # rollupTree 0.2.0
 
-* Added fault tree example
+* Fault tree example added.
 
-* Documentation cleanup
+* Documentation cleaned up.
 
-* Added create_rollup_tree() convenience function
+* `create_rollup_tree()` (new) creates a tree suitable for `rollup()` from a data
+    frame with child/parent identifier pairs.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 # rollupTree
 
 <!-- badges: start -->
+
 <!-- badges: end -->
 
 rollupTree implements a general function for computations in which some

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,10 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 
-* This is a new release.
+## revdepcheck results
+
+We checked 1 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+
+ * We saw 0 new problems
+ * We failed to check 0 packages


### PR DESCRIPTION
Changes here should have been on main. Merging and will delete branch. Probably will not implement this. Finding the root is unnecessary for `rollup()` but might be useful advance tree validation.